### PR TITLE
Clean security group rules

### DIFF
--- a/roles/k8s/tasks/create_secgroup_rules.yml
+++ b/roles/k8s/tasks/create_secgroup_rules.yml
@@ -10,39 +10,16 @@
 
 # Rules for the k8s security group
 
-  - name: SSH for k8s
+# internal
+  - name: flannel etcd 2379
     local_action:
      module: cs_securitygroup_rule
      security_group: "{{ k8s_security_group_name }}"
-     start_port: 22
-     end_port: 22
-
-#etcd
-  - name: etcd 4001
-    local_action:
-     module: cs_securitygroup_rule
-     security_group: "{{ k8s_security_group_name }}"
-     start_port: 4001
-     end_port: 4001
+     start_port: 2379
+     end_port: 2379
      user_security_group: "{{ k8s_security_group_name }}"
 
-  - name: etcd 7001
-    local_action:
-     module: cs_securitygroup_rule
-     security_group: "{{ k8s_security_group_name }}"
-     start_port: 7001
-     end_port: 7001
-     user_security_group: "{{ k8s_security_group_name }}"
-
-  - name: etcd 2379
-    local_action:
-     module: cs_securitygroup_rule
-     security_group: "{{ k8s_security_group_name }}"
-     start_port: 7001
-     end_port: 7001
-     user_security_group: "{{ k8s_security_group_name }}"
-
-  - name: etcd 2380
+  - name: flannel etcd 2380
     local_action:
      module: cs_securitygroup_rule
      security_group: "{{ k8s_security_group_name }}"
@@ -50,12 +27,12 @@
      end_port: 2380
      user_security_group: "{{ k8s_security_group_name }}"
 
-  - name: k8s secure
+  - name: k8s 8080
     local_action:
      module: cs_securitygroup_rule
      security_group: "{{ k8s_security_group_name }}"
-     start_port: 443
-     end_port: 443
+     start_port: 8080
+     end_port: 8080
      user_security_group: "{{ k8s_security_group_name }}"
 
   - name: flannel UDP 8472
@@ -76,14 +53,14 @@
      protocol: tcp
      user_security_group: "{{ k8s_security_group_name }}"
 
-#k8s api
-  - name: k8s 8080
+# external access
+
+  - name: SSH for k8s
     local_action:
      module: cs_securitygroup_rule
      security_group: "{{ k8s_security_group_name }}"
-     start_port: 8080
-     end_port: 8080
-     user_security_group: "{{ k8s_security_group_name }}"
+     start_port: 22
+     end_port: 22
 
   - name: k8s public secure
     local_action:

--- a/roles/k8s/templates/k8s-master.j2
+++ b/roles/k8s/templates/k8s-master.j2
@@ -62,10 +62,10 @@ coreos:
 
   etcd2:
     name: master
-    listen-client-urls: http://0.0.0.0:2379,http://0.0.0.0:4001
-    advertise-client-urls: http://$private_ipv4:2379,http://$private_ipv4:4001
+    listen-client-urls: http://0.0.0.0:2379
+    advertise-client-urls: http://$private_ipv4:2379
     initial-cluster-token: k8s_etcd
-    listen-peer-urls: http://$private_ipv4:2380,http://$private_ipv4:7001
+    listen-peer-urls: http://$private_ipv4:2380
     initial-advertise-peer-urls: http://$private_ipv4:2380
     initial-cluster: master=http://$private_ipv4:2380
     initial-cluster-state: new

--- a/roles/k8s/templates/k8s-node.j2
+++ b/roles/k8s/templates/k8s-node.j2
@@ -11,8 +11,8 @@ write-files:
       exit $?
 coreos:
   etcd2:
-    listen-client-urls: http://0.0.0.0:2379,http://0.0.0.0:4001
-    advertise-client-urls: http://0.0.0.0:2379,http://0.0.0.0:4001
+    listen-client-urls: http://0.0.0.0:2379
+    advertise-client-urls: http://0.0.0.0:2379
     initial-cluster: master=http://{{ k8s_master.default_ip }}:2380
     proxy: on
   fleet:


### PR DESCRIPTION
This PR does not fix anything broken but simply cleans up the security group rules and the cluster internal etcd communication.
- make sure legacy etcd ports are not used
- remove legacy etcd ports
- remove obsolete internal 443 rule
- order rules by port ascending, private rules first
